### PR TITLE
Use an object for the setHandler arguments

### DIFF
--- a/lib/mutation.class.js
+++ b/lib/mutation.class.js
@@ -145,7 +145,7 @@ export default class Mutation {
 
                 let error, result;
                 try {
-                    result = fn.call(null, this, params);
+                    result = fn.call(null, { context: this, params });
                 } catch (e) {
                     error = e;
                 }


### PR DESCRIPTION
This would make the setHandler function get a single object as well, like most functions in this package.

If this change is accepted, I'll edit the README as well!