### PR TITLE
Send the correct `params` to the `addAfterCall` hook

### DIFF
--- a/lib/mutation.class.js
+++ b/lib/mutation.class.js
@@ -102,7 +102,7 @@ export default class Mutation {
             Meteor.apply(name, [callParams], options, (error, result) => {
                 const aopData = {
                     config,
-                    params,
+                    params: callParams,
                     result,
                     error,
                 };


### PR DESCRIPTION
Currently, the mutation's config `params` are wrongly sent in the `addAfterCall` hook. This PR fixes this by sending the params with which the `run` method is called.