### PR TITLE
Allow calling methods without arguments

### DIFF
--- a/lib/mutation.class.js
+++ b/lib/mutation.class.js
@@ -89,7 +89,7 @@ export default class Mutation {
      * @param {Object} options Meteor options https://docs.meteor.com/api/methods.html#Meteor-apply
      * @returns {Promise}
      */
-    run(callParams, options = {}) {
+    run(callParams = {}, options = {}) {
         const config = this.config;
 
         const aopData = { config, params: callParams };


### PR DESCRIPTION
When the only arguments needed are optional, this is useful.

Closes #6 